### PR TITLE
강사님 피드백 반영 후 UI 수정

### DIFF
--- a/Wellnest/Wellnest/Feature/Onboarding/Model/ActivityPreferenceList.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/ActivityPreferenceList.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct ActivityPreference: SelectableItem {
     let id = UUID()
-    let icon: String?
+    let icon: String
     let category: String
     var isSelected: Bool = false
 //    let randomCardColor: Color
@@ -29,6 +29,7 @@ struct ActivityPreference: SelectableItem {
 //        self.randomCardColor = ActivityPreference.availableCardColors.randomElement()!
 //    }
 
+    // TODO: 사용자 정보에서 성별 선택에 따라 아이콘을 성별에 맞게 바꿔보기
     static let activities: [ActivityPreference] = [
         ActivityPreference(icon: "🚶🏽‍♂", category: "걷기/산책"),
         ActivityPreference(icon: "🏃🏾‍♂️", category: "달리기"),
@@ -43,13 +44,13 @@ struct ActivityPreference: SelectableItem {
         ActivityPreference(icon: "🩰", category: "요가/필라테스/발레"),
         ActivityPreference(icon: "💃🏽", category: "댄스 스포츠"),
         ActivityPreference(icon: "🧘🏾", category: "명상"),
-        ActivityPreference(icon: "🔍", category: "기타"),
-        ActivityPreference(icon: "", category: "특별히 없음")
+        ActivityPreference(icon: "❔", category: "기타"),
+        ActivityPreference(icon: "💬", category: "특별히 없음")
     ]
 }
 
 protocol SelectableItem: Identifiable, Equatable {
-    var icon: String? { get }
+    var icon: String { get }
     var category: String { get }
     var isSelected: Bool { get set }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/Model/GenderSelectionModel.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/GenderSelectionModel.swift
@@ -1,0 +1,14 @@
+//
+//  GenderSelectionModel.swift
+//  Wellnest
+//
+//  Created by 정소이 on 8/10/25.
+//
+
+import SwiftUI
+import Combine
+
+class GenderSelectionModel: ObservableObject {
+    @Published var selectedGender: String = ""
+    let genderOptions = ["여성 👩🏻", "남성 👨🏻"]
+}

--- a/Wellnest/Wellnest/Feature/Onboarding/Model/HealthConditionList.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/HealthConditionList.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct HealthCondition: SelectableItem {
     let id = UUID()
-    let icon: String?
+    let icon: String
     let category: String
     var isSelected: Bool = false
 
@@ -25,6 +25,6 @@ struct HealthCondition: SelectableItem {
         HealthCondition(icon: "😵‍💫", category: "번아웃"),
         HealthCondition(icon: "🍜", category: "과식/불규칙한 식사"),
         HealthCondition(icon: "💤", category: "수면 문제"),
-        HealthCondition(icon: "🔍", category: "기타")
+        HealthCondition(icon: "❔", category: "기타")
     ]
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/Model/PreferredTimeSlotList.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/PreferredTimeSlotList.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct PreferredTimeSlot: SelectableItem {
     let id = UUID()
-    let icon: String?
+    let icon: String
     let category: String
     var isSelected: Bool = false
 
@@ -18,7 +18,7 @@ struct PreferredTimeSlot: SelectableItem {
         PreferredTimeSlot(icon: "🕛", category: "점심"),
         PreferredTimeSlot(icon: "🕖", category: "오후"),
         PreferredTimeSlot(icon: "🌜", category: "밤/새벽"),
-        PreferredTimeSlot(icon: "🔍", category: "기타"),
-        PreferredTimeSlot(icon: "", category: "특별히 없음")
+        PreferredTimeSlot(icon: "❔", category: "기타"),
+        PreferredTimeSlot(icon: "💬", category: "특별히 없음")
     ]
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/Model/WeatherPreferenceList.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/WeatherPreferenceList.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct WeatherPreference: SelectableItem {
     let id = UUID()
-    let icon: String?
+    let icon: String
     let category: String
     var isSelected: Bool = false
 
@@ -18,7 +18,7 @@ struct WeatherPreference: SelectableItem {
         WeatherPreference(icon: "🌥️", category: "흐림"),
         WeatherPreference(icon: "🌧️", category: "비"),
         WeatherPreference(icon: "🌨️", category: "눈"),
-        WeatherPreference(icon: "🔍", category: "기타"),
-        WeatherPreference(icon: "", category: "특별히 없음")
+        WeatherPreference(icon: "❔", category: "기타"),
+        WeatherPreference(icon: "💬", category: "특별히 없음")
     ]
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/Model/WellnessGoalList.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/Model/WellnessGoalList.swift
@@ -18,6 +18,6 @@ struct WellnessGoal: Identifiable {
         WellnessGoal(title: "💤  수면과 회복의 질 향상"),
         WellnessGoal(title: "🥗  건강한 식습관 형성"),
         WellnessGoal(title: "🏋🏻‍♀️  체중 감량 또는 증가"),
-        WellnessGoal(title: "특별히 없음")
+        WellnessGoal(title: "💬  특별히 없음")
     ]
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/OnboardingTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/OnboardingTabView.swift
@@ -7,52 +7,15 @@
 
 import SwiftUI
 
-struct OnboardingTitle: View {
-    let title: String
-    let description: String?
-    let currentPage: Int
-    let onBack: () -> Void
+struct OnboardingTitleDescription: View {
+    let description: String
 
     var body: some View {
-        HStack {
-            if currentPage > 0 {
-                Button {
-                    onBack()
-                } label: {
-                    Image(systemName: "chevron.backward")
-                        .font(.title2)
-                        .foregroundColor(.primary)
-                }
-            } else {
-                Image(systemName: "chevron.backward")
-                    .font(.title2)
-                    .opacity(0)
-            }
-
-            Spacer()
-
-            Text(title)
-                .font(.title2)
-                .fontWeight(.bold)
-
-            Spacer()
-
-            // 타이틀을 가운데에 배치하기 위함
-            Image(systemName: "chevron.backward")
-                    .opacity(0)
-                    .font(.title2)
-        }
-        .padding(.horizontal)
-        .padding(.top)
-
-        if let description {
-            Text(description)
-                .font(.caption)
-                .multilineTextAlignment(.center)
-                .padding(.top, Spacing.content)
-                .padding(.horizontal)
-                .padding(.bottom, 60)
-        }
+        Text(description)
+            .multilineTextAlignment(.center)
+            .padding(.top, Spacing.content)
+            .padding(.horizontal)
+            .padding(.bottom, 60)
     }
 }
 
@@ -95,6 +58,7 @@ struct OnboardingCardContent<Item: SelectableItem>: View {
             HStack {
                 Text("* 중복 선택 가능")
                     .font(.caption2)
+                    .foregroundColor(.primary.opacity(0.5))
                 Spacer()
             }
             .padding(.horizontal, Spacing.content)
@@ -108,17 +72,16 @@ struct OnboardingCardContent<Item: SelectableItem>: View {
                         }
                     } label: {
                         VStack(spacing: Spacing.inline) {
-                            if let icon = item.icon, !icon.isEmpty {
-                                Text(icon)
+                            Text(item.icon)
                                     .font(.system(size: 60))
-                            }
+                                    .saturation(item.isSelected ? 1 : 0) // 채도 조절
 
                             Text(item.category)
                                 .fontWeight(.semibold)
-                                .foregroundColor(.black)
+                                .foregroundColor(item.isSelected ? .white : .secondary)
                         }
                         .frame(width: cardWidth, height: cardWidth)
-                        .background(item.isSelected ? .accentCardYellow : .customSecondary)
+                        .background(item.isSelected ? .blue : .customSecondary)
                         .cornerRadius(CornerRadius.large)
                     }
                     .defaultShadow()
@@ -135,78 +98,94 @@ struct OnboardingTabView: View {
     @ObservedObject var userDefaultsManager: UserDefaultsManager
 
     @State private var currentPage: Int = 0
+    @State private var title: String = ""
 
 //    init(startPage: Int = 0) {
 //        _currentPage = State(initialValue: startPage)
 //    }
 
     var body: some View {
-        VStack {
-            // 사용자 입력을 받지 않아도 페이징이 되는 걸 막기 위함
-            switch currentPage {
-            case 0:
-                MotivationTabView(currentPage: $currentPage)
-            case 1:
-                IntroductionTabView(currentPage: $currentPage)
-            case 2:
-                IntroductionTabView(currentPage: $currentPage)
-            case 3:
-                UserInfoTabView(currentPage: $currentPage)
-            case 4:
-                WellnessGoalTabView(currentPage: $currentPage)
-            case 5:
-                ActivityPreferenceTabView(currentPage: $currentPage)
-            case 6:
-                PreferredTimeSlotTabView(currentPage: $currentPage)
-            case 7:
-                WeatherPreferenceTabView(currentPage: $currentPage)
-            case 8:
-                HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage)
-            default:
-                EmptyView()
-            }
-//            TabView(selection: $currentPage) {
-//                MotivationTabView(currentPage: $currentPage)
-//                    .tag(0)
-//
-//                IntroductionTabView(currentPage: $currentPage)
-//                    .tag(1)
-//
-//                IntroductionTabView(currentPage: $currentPage)
-//                    .tag(2)
-//
-//                UserInfoTabView(currentPage: $currentPage)
-//                    .tag(3)
-//
-//                WellnessGoalTabView(currentPage: $currentPage)
-//                    .tag(4)
-//
-//                ActivityPreferenceTabView(currentPage: $currentPage)
-//                    .tag(5)
-//
-//                PreferredTimeSlotTabView(currentPage: $currentPage)
-//                    .tag(6)
-//
-//                WeatherPreferenceTabView(currentPage: $currentPage)
-//                    .tag(7)
-//
-//                HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage)
-//                    .tag(8)
-//            }
-//            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        NavigationView {
+            VStack {
+                // 사용자 입력을 받지 않아도 페이징이 되는 걸 막기 위함
+                switch currentPage {
+                case 0:
+                    MotivationTabView(currentPage: $currentPage, title: $title)
+                case 1:
+                    IntroductionTabView(currentPage: $currentPage, title: $title)
+                case 2:
+                    IntroductionTabView(currentPage: $currentPage, title: $title)
+                case 3:
+                    UserInfoTabView(currentPage: $currentPage, title: $title)
+                case 4:
+                    WellnessGoalTabView(currentPage: $currentPage, title: $title)
+                case 5:
+                    ActivityPreferenceTabView(currentPage: $currentPage, title: $title)
+                case 6:
+                    PreferredTimeSlotTabView(currentPage: $currentPage, title: $title)
+                case 7:
+                    WeatherPreferenceTabView(currentPage: $currentPage, title: $title)
+                case 8:
+                    HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage, title: $title)
+                default:
+                    EmptyView()
+                }
+                // TabView(selection: $currentPage) {
+                //                MotivationTabView(currentPage: $currentPage)
+                //                    .tag(0)
+                //
+                //                IntroductionTabView(currentPage: $currentPage)
+                //                    .tag(1)
+                //
+                //                IntroductionTabView(currentPage: $currentPage)
+                //                    .tag(2)
+                //
+                //                UserInfoTabView(currentPage: $currentPage)
+                //                    .tag(3)
+                //
+                //                WellnessGoalTabView(currentPage: $currentPage)
+                //                    .tag(4)
+                //
+                //                ActivityPreferenceTabView(currentPage: $currentPage)
+                //                    .tag(5)
+                //
+                //                PreferredTimeSlotTabView(currentPage: $currentPage)
+                //                    .tag(6)
+                //
+                //                WeatherPreferenceTabView(currentPage: $currentPage)
+                //                    .tag(7)
+                //
+                //                HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage)
+                //                    .tag(8)
+                //            }
+                //            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
 
-            // Custom Indicator
-//            if currentPage < totalPages {
-//                HStack(spacing: 8) {
-//                    ForEach(0 ..< totalPages, id: \.self) { index in
-//                        Circle()
-//                            .fill(index == currentPage ? Color.primary : Color.secondary.opacity(0.3))
-//                            .frame(width: 8, height: 8)
-//                    }
-//                }
-//            }
+                // Custom Indicator
+                //            if currentPage < totalPages {
+                //                HStack(spacing: 8) {
+                //                    ForEach(0 ..< totalPages, id: \.self) { index in
+                //                        Circle()
+                //                            .fill(index == currentPage ? Color.primary : Color.secondary.opacity(0.3))
+                //                            .frame(width: 8, height: 8)
+                //                    }
+                //                }
+                //            }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    if currentPage > 0 {
+                        Button {
+                            withAnimation { currentPage -= 1 }
+                        } label: {
+                            Image(systemName: "chevron.backward")
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
+            }
         }
-//        .ignoresSafeArea()
     }
 }
 

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/ActivityPreferenceTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/ActivityPreferenceTabView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ActivityPreferenceTabView: View {
     @Binding var currentPage: Int
+    @Binding var title: String
 
     @State private var activities = ActivityPreference.activities
 
@@ -18,7 +19,7 @@ struct ActivityPreferenceTabView: View {
 
     var body: some View {
         ScrollView {
-            OnboardingTitle(title: "선호 활동", description: "평소에 선호하는 운동이나 활동을 골라주세요.", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "평소에 선호하는 운동이나 활동을 골라주세요.")
 
             OnboardingCardContent(items: $activities)
         }
@@ -32,7 +33,12 @@ struct ActivityPreferenceTabView: View {
             .disabled(isButtonDisabled)
             .opacity(isButtonDisabled ? 0.5 : 1.0)
             .padding()
-            .background(.white)
+//            .background(.white) // TODO: 방법 1) 하얀색 배경
+            .background(.ultraThinMaterial) // TODO: 방법 2) 블러 배경
+                                            // TODO: 방법 3) 배경 없음(투명)
+        }
+        .onAppear {
+            title = "선호 활동"
         }
     }
 }
@@ -43,8 +49,9 @@ struct ActivityPreferenceTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = ""
 
     var body: some View {
-        ActivityPreferenceTabView(currentPage: $currentPage)
+        ActivityPreferenceTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/HealthConditionTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/HealthConditionTabView.swift
@@ -11,6 +11,7 @@ struct HealthConditionTabView: View {
     @ObservedObject var userDefaultsManager: UserDefaultsManager
     
     @Binding var currentPage: Int
+    @Binding var title: String
 
     @State private var conditions = HealthCondition.conditions
 
@@ -20,19 +21,24 @@ struct HealthConditionTabView: View {
 
     var body: some View {
         ScrollView {
-            OnboardingTitle(title: "현재 건강 상태", description: "현재 건강 상태에 해당하는 특별한 이슈가 있나요?", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "현재 건강 상태에 해당하는 특별한 이슈가 있나요?")
 
             OnboardingCardContent(items: $conditions)
         }
         .scrollIndicators(.hidden)
         .safeAreaInset(edge: .bottom) {
             FilledButton(title: "완료") {
-                userDefaultsManager.isOnboarding = true
+                withAnimation {
+                    userDefaultsManager.isOnboarding = true
+                }
             }
             .disabled(isButtonDisabled)
             .opacity(isButtonDisabled ? 0.5 : 1.0)
             .padding()
             .background(.white)
+        }
+        .onAppear {
+            title = "현재 건강 상태"
         }
     }
 }
@@ -43,8 +49,9 @@ struct HealthConditionTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = ""
 
     var body: some View {
-        HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage)
+        HealthConditionTabView(userDefaultsManager: UserDefaultsManager.shared, currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/IntroductionTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/IntroductionTabView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct IntroductionTabView: View {
     @Binding var currentPage: Int
-    
+    @Binding var title: String
+
     var body: some View {
         VStack {
-            OnboardingTitle(title: "앱 소개", description: "", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
-
             Spacer()
 
             FilledButton(title: "다음") {
@@ -22,6 +21,9 @@ struct IntroductionTabView: View {
                 }
             }
             .padding()
+        }
+        .onAppear {
+            title = "앱 소개"
         }
     }
 }
@@ -32,8 +34,9 @@ struct IntroductionTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = "앱 소개"
 
     var body: some View {
-        IntroductionTabView(currentPage: $currentPage)
+        IntroductionTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/MotivationTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/MotivationTabView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct MotivationTabView: View {
     @Binding var currentPage: Int
+    @Binding var title: String
 
     var body: some View {
         VStack {
-            OnboardingTitle(title: "동기부여 문구", description: "", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
-
             Spacer()
 
             FilledButton(title: "다음") {
@@ -22,6 +21,9 @@ struct MotivationTabView: View {
                 }
             }
             .padding()
+        }
+        .onAppear {
+            title = "동기부여 문구"
         }
     }
 }
@@ -32,8 +34,9 @@ struct MotivationTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = "동기부여 문구"
 
     var body: some View {
-        MotivationTabView(currentPage: $currentPage)
+        MotivationTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/PreferredTimeSlotTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/PreferredTimeSlotTabView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PreferredTimeSlotTabView: View {
     @Binding var currentPage: Int
+    @Binding var title: String
 
     @State private var timeSlots = PreferredTimeSlot.timeSlots
 
@@ -18,7 +19,7 @@ struct PreferredTimeSlotTabView: View {
 
     var body: some View {
         ScrollView {
-            OnboardingTitle(title: "활동 시간대", description: "앞에서 선택하신 활동은 주로 언제 하시나요?", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "앞에서 선택하신 활동은 주로 언제 하시나요?")
 
             OnboardingCardContent(items: $timeSlots)
         }
@@ -34,6 +35,9 @@ struct PreferredTimeSlotTabView: View {
             .padding()
             .background(.white)
         }
+        .onAppear {
+            title = "활동 시간대"
+        }
     }
 }
 
@@ -43,8 +47,9 @@ struct PreferredTimeSlotTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = ""
 
     var body: some View {
-        PreferredTimeSlotTabView(currentPage: $currentPage)
+        PreferredTimeSlotTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/UserInfoTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/UserInfoTabView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct UserInfoTabView: View {
     @Binding var currentPage: Int
+    @Binding var title: String
 
     @State private var nickname: String = ""
     @FocusState private var isNicknameFieldFocused: Bool
@@ -16,16 +17,11 @@ struct UserInfoTabView: View {
     @State private var selectedAge = ""
     let ageOptions = ["10대", "20대", "30대", "40대", "50대", "60대 이상"]
 
-    @State var selectedGender = ""
-    var genderOptions = ["여자", "남자"]
+    @State private var selectedGender = ""
+    let genderOptions = ["여성 👩🏻", "남성 👨🏻"]
 
     @State private var height: Int?
-//    @State private var selectedHeight = ""
-//    let heightOptions = ["140대 이하", "150대", "160대", "170대", "180대", "190대 이상"]
-
     @State private var weight: Int?
-//    @State private var selectedWeight = ""
-//    let weightOptions = ["20kg대 이하", "30kg대", "40kg대", "50kg대", "60kg대", "70kg대", "80kg대", "90kg대", "100kg대 이상"]
 
     let spacing = OnboardingCardLayout.spacing
 
@@ -35,18 +31,9 @@ struct UserInfoTabView: View {
 
     var body: some View {
         VStack {
-            OnboardingTitle(title: "사용자 정보", description: "당신의 정보를 알려주시면 그에 맞게 루틴을 추천해줄게요.", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "당신의 정보를 알려주시면 그에 맞게 루틴을 추천해줄게요.")
 
             VStack {
-                HStack {
-                    Text("* 필수항목")
-                        .font(.caption2)
-
-                    Spacer()
-                }
-                .padding(.horizontal, Spacing.content)
-                .padding(.bottom, Spacing.content)
-
                 /// 닉네임
                 UserInfoForm(title: "닉네임", isRequired: true) {
                     TextField(
@@ -54,7 +41,7 @@ struct UserInfoTabView: View {
                         text: $nickname,
                         prompt: Text("10글자 이하로 입력해주세요.")
                             .font(.footnote)
-                            .foregroundColor(.gray)
+                            .foregroundColor(.secondary.opacity(0.4)) // TODO: 임시 컬러
                     )
                     .foregroundColor(.black)
                     .padding(.horizontal)
@@ -72,43 +59,6 @@ struct UserInfoTabView: View {
                     }
                 }
 
-//                HStack {
-//                    UserInfoFormTitle(title: "닉네임 *")
-//
-//                    TextField(
-//                        "",
-//                        text: $nickname,
-//                        prompt: Text("10글자 이하로 입력해주세요.")
-//                            .font(.footnote)
-//                            .foregroundColor(.gray)
-//                    )
-//                    .foregroundColor(.black)
-//                    .padding(.horizontal)
-//                    .padding(.leading, 10)
-//                    .focused($isNicknameFieldFocused)
-//                    .textInputAutocapitalization(.never)
-//                    .autocorrectionDisabled()
-//                    .onChange(of: nickname) { newValue in
-//                        let filtered = newValue
-//                            .filter { $0.isLetter || $0.isNumber }
-//                            .prefix(10)
-//
-//                        if nickname != String(filtered) {
-//                            nickname = String(filtered)
-//                        }
-//                    }
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
-//                .onAppear {
-//                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-//                        isNicknameFieldFocused = true
-//                    }
-//                }
-
                 /// 연령대
                 UserInfoForm(title: "연령대", isRequired: true) {
                     Menu {
@@ -122,7 +72,7 @@ struct UserInfoTabView: View {
                     } label: {
                         HStack {
                             Text(selectedAge.isEmpty ? "연령대를 선택해주세요." : selectedAge)
-                                .foregroundColor(selectedAge.isEmpty ? .gray : .black)
+                                .foregroundColor(selectedAge.isEmpty ? .gray.opacity(0.5) : .black)
                                 .font(selectedAge.isEmpty ? .footnote : .body)
 
                             Spacer()
@@ -138,58 +88,9 @@ struct UserInfoTabView: View {
                     .padding(.leading, 10)
                 }
 
-//                HStack {
-//                    UserInfoFormTitle(title: "연령대 *")
-//
-//                    Menu {
-//                        ForEach(ageOptions, id: \.self) { age in
-//                            Button(action: {
-//                                selectedAge = age
-//                            }) {
-//                                Text(age)
-//                            }
-//                        }
-//                    } label: {
-//                        HStack {
-//                            Text(selectedAge.isEmpty ? "연령대를 선택해주세요." : selectedAge)
-//                                .foregroundColor(selectedAge.isEmpty ? .gray : .black)
-//                                .font(selectedAge.isEmpty ? .footnote : .body)
-//
-//                            Spacer()
-//
-//                            // TODO: 메뉴 클릭 시 chevron.up으로 바뀌는 것도 좋을 것 같음
-//                            Image(systemName: "chevron.down")
-//                                .foregroundColor(.primary)
-//                                .imageScale(.small)
-//                        }
-//                        .frame(maxWidth: .infinity)
-//                    }
-//                    .padding(.horizontal)
-//                    .padding(.leading, 10)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
-
                 /// 성별
                 UserInfoForm(title: "성별", isRequired: true) {
                     // TODO: picker 다크모드 대응
-                    Picker("", selection: $selectedGender) {
-                        ForEach(genderOptions, id: \.self) {
-                            Text($0)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .padding()
-                    .padding(.leading, 20)
-                }
-
-//                HStack {
-//                    UserInfoFormTitle(title: "성별 *")
-//
-//                    // TODO: picker 다크모드 대응
 //                    Picker("", selection: $selectedGender) {
 //                        ForEach(genderOptions, id: \.self) {
 //                            Text($0)
@@ -197,47 +98,29 @@ struct UserInfoTabView: View {
 //                    }
 //                    .pickerStyle(.segmented)
 //                    .padding()
-//                    .padding(.leading, 20)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
+//                    .padding(.leading, 16)
 
-//                HStack {
-//                    UserInfoSectionTitle(title: "키")
-//
-//                    Menu {
-//                        ForEach(heightOptions, id: \.self) { height in
-//                            Button(action: {
-//                                selectedHeight = height
-//                            }) {
-//                                Text(height)
-//                            }
-//                        }
-//                    } label: {
-//                        HStack {
-//                            Text(selectedHeight.isEmpty ? "키를 선택해주세요." : selectedHeight)
-//                                .foregroundColor(selectedHeight.isEmpty ? .gray : .primary)
-//                                .font(selectedHeight.isEmpty ? .footnote : .body)
-//
-//                            Spacer()
-//
-//                            Image(systemName: "chevron.down")
-//                                .foregroundColor(.primary)
-//                                .imageScale(.small)
-//                        }
-//                        .frame(maxWidth: .infinity)
-//                    }
-//                    .padding(.trailing)
-//                    .padding(.leading, 60)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
+                    HStack(spacing: 10) {
+                        ForEach(genderOptions, id: \.self) { option in
+                            Button {
+                                selectedGender = option
+                            } label: {
+                                Text(option)
+                                    .font(.body)
+                                    .frame(width: 80, height: 30)
+                                    .multilineTextAlignment(.center)
+                                    .background(
+                                        Capsule()
+                                            .fill(selectedGender == option ? .blue : Color.gray.opacity(0.2))
+                                    )
+                                    .foregroundColor(selectedGender == option ? .white : .primary)
+                            }
+                        }
+                    }
+                    .padding(.leading, 36)
+
+                    Spacer()
+                }
 
                 /// 키
                 UserInfoForm(title: "키") {
@@ -249,144 +132,31 @@ struct UserInfoTabView: View {
                         ),
                         prompt: Text("cm 단위로 정수만 입력해주세요.")
                             .font(.footnote)
-                            .foregroundColor(.gray)
+                            .foregroundColor(.gray.opacity(0.5))
                     )
                     .keyboardType(.decimalPad)
                     .foregroundColor(.black)
                     .padding(.horizontal)
-                    .padding(.leading, 42)
+                    .padding(.leading, 46)
                 }
-
-//                HStack {
-//                    UserInfoFormTitle(title: "키")
-//
-//                    TextField(
-//                        "",
-//                        text: Binding(
-//                            get: {
-//                                if let height = height {
-//                                    return String(height)
-//                                } else {
-//                                    return ""
-//                                }
-//                            },
-//                            set: { newValue in
-//                                let filtered = newValue.filter { $0.isNumber }
-//                                let limited = String(filtered.prefix(3))
-//
-//                                if let value = Int(limited) {
-//                                    height = value
-//                                } else {
-//                                    height = nil
-//                                }
-//                            }
-//                        ),
-//                        prompt: Text("cm 단위로 정수만 입력해주세요.")
-//                            .font(.footnote)
-//                            .foregroundColor(.gray)
-//                    )
-//                    .keyboardType(.decimalPad)
-//                    .foregroundColor(.black)
-//                    .padding(.horizontal)
-//                    .padding(.leading, 42)
-//
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
-
-//                HStack {
-//                    UserInfoSectionTitle(title: "몸무게")
-//
-//                    Menu {
-//                        ForEach(weightOptions, id: \.self) { weight in
-//                            Button(action: {
-//                                selectedWeight = weight
-//                            }) {
-//                                Text(weight)
-//                            }
-//                        }
-//                    } label: {
-//                        HStack {
-//                            Text(selectedWeight.isEmpty ? "몸무게를 선택해주세요." : selectedWeight)
-//                                .foregroundColor(selectedWeight.isEmpty ? .gray : .primary)
-//                                .font(selectedWeight.isEmpty ? .footnote : .body)
-//
-//                            Spacer()
-//
-//                            Image(systemName: "chevron.down")
-//                                .foregroundColor(.primary)
-//                                .imageScale(.small)
-//                        }
-//                        .frame(maxWidth: .infinity)
-//                    }
-//                    .padding(.trailing)
-//                    .padding(.leading, 30)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
 
                 /// 몸무게
                 UserInfoForm(title: "몸무게") {
                     TextField(
                         "",
                         text: Binding(
-                            get: { height.map(String.init) ?? "" },
-                            set: { height = Int($0.onlyNumbers(maxLength: 3)) }
+                            get: { weight.map(String.init) ?? "" },
+                            set: { weight = Int($0.onlyNumbers(maxLength: 3)) }
                         ),
                         prompt: Text("kg 단위로 정수만 입력해주세요.")
                             .font(.footnote)
-                            .foregroundColor(.gray)
+                            .foregroundColor(.gray.opacity(0.5))
                     )
                     .keyboardType(.decimalPad)
                     .foregroundColor(.black)
                     .padding(.horizontal)
-                    .padding(.leading, 14)
+                    .padding(.leading, 18)
                 }
-
-//                HStack {
-//                    UserInfoFormTitle(title: "몸무게")
-//
-//                    TextField(
-//                        "",
-//                        text: Binding(
-//                            get: {
-//                                if let weight = weight {
-//                                    return String(weight)
-//                                } else {
-//                                    return ""
-//                                }
-//                            },
-//                            set: { newValue in
-//                                let filtered = newValue.filter { $0.isNumber }
-//                                let limited = String(filtered.prefix(3))
-//
-//                                if let value = Int(limited) {
-//                                    weight = value
-//                                } else {
-//                                    weight = nil
-//                                }
-//                            }
-//                        ),
-//                        prompt: Text("kg 단위로 정수만 입력해주세요.")
-//                            .font(.footnote)
-//                            .foregroundColor(.gray)
-//                    )
-//                    .keyboardType(.decimalPad)
-//                    .foregroundColor(.black)
-//                    .padding(.horizontal)
-//                    .padding(.leading, 14)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .frame(height: 58)
-//                .background(.customSecondary)
-//                .cornerRadius(CornerRadius.large)
-//                .padding(.bottom, Spacing.content)
             }
             .padding(.horizontal, spacing)
 
@@ -400,6 +170,9 @@ struct UserInfoTabView: View {
             .disabled(isButtonDisabled)
             .opacity(isButtonDisabled ? 0.5 : 1.0)
             .padding()
+        }
+        .onAppear {
+            title = "사용자 정보"
         }
         .onTapGesture {
             UIApplication.hideKeyboard()
@@ -450,8 +223,9 @@ struct UserInfoForm<Content: View>: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = "사용자 정보"
 
     var body: some View {
-        UserInfoTabView(currentPage: $currentPage)
+        UserInfoTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/WeatherPreferenceTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/WeatherPreferenceTabView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WeatherPreferenceTabView: View {
     @Binding var currentPage: Int
+    @Binding var title: String
 
     @State private var weathers = WeatherPreference.weathers
 
@@ -18,7 +19,7 @@ struct WeatherPreferenceTabView: View {
 
     var body: some View {
         ScrollView {
-            OnboardingTitle(title: "선호 날씨", description: "평소에 어떤 날씨를 좋아하시나요?", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "평소에 어떤 날씨를 좋아하시나요?")
 
             OnboardingCardContent(items: $weathers)
         }
@@ -34,6 +35,9 @@ struct WeatherPreferenceTabView: View {
             .padding()
             .background(.white)
         }
+        .onAppear {
+            title = "선호 날씨"
+        }
     }
 }
 
@@ -43,8 +47,9 @@ struct WeatherPreferenceTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = ""
 
     var body: some View {
-        WeatherPreferenceTabView(currentPage: $currentPage)
+        WeatherPreferenceTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Feature/Onboarding/View/SubView/WellnessGoalTabView.swift
+++ b/Wellnest/Wellnest/Feature/Onboarding/View/SubView/WellnessGoalTabView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct WellnessGoalTabView: View {
     @Binding var currentPage: Int
-    
+    @Binding var title: String
+
     @State private var goals = WellnessGoal.goals
 
     let spacing = OnboardingCardLayout.spacing
@@ -20,12 +21,13 @@ struct WellnessGoalTabView: View {
 
     var body: some View {
         VStack {
-            OnboardingTitle(title: "웰니스 목표", description: "삶의 질을 높이고 지속 가능한 건강 루틴을 만드는 것에 집중해보세요.", currentPage: currentPage, onBack: { withAnimation { currentPage -= 1 } })
+            OnboardingTitleDescription(description: "삶의 질을 높이고 지속 가능한 건강 루틴을 만드는 것에 집중해보세요.")
 
             VStack {
                 HStack {
                     Text("* 중복 선택 가능")
                         .font(.caption2)
+                        .foregroundColor(.primary.opacity(0.5))
                     Spacer()
                 }
                 .padding(.horizontal, Spacing.content)
@@ -40,11 +42,14 @@ struct WellnessGoalTabView: View {
                         HStack {
                             Text(goal.title)
                                 .fontWeight(.semibold)
-                                .foregroundColor(.black)
+                                .foregroundColor(goal.isSelected ? .white : .secondary)
+                                .padding(.leading)
+
+                            Spacer()
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 58)
-                        .background(goal.isSelected ? .accentCardYellow : .customSecondary)
+                        .background(goal.isSelected ? .blue : .customSecondary)
                         .cornerRadius(CornerRadius.large)
                     }
                     .padding(.bottom, Spacing.content)
@@ -64,6 +69,9 @@ struct WellnessGoalTabView: View {
             .opacity(isButtonDisabled ? 0.5 : 1.0)
             .padding()
         }
+        .onAppear {
+            title = "웰니스 목표"
+        }
     }
 }
 
@@ -73,8 +81,9 @@ struct WellnessGoalTabView: View {
 
 private struct Preview: View {
     @State private var currentPage = 0
+    @State private var title = ""
 
     var body: some View {
-        WellnessGoalTabView(currentPage: $currentPage)
+        WellnessGoalTabView(currentPage: $currentPage, title: $title)
     }
 }

--- a/Wellnest/Wellnest/Resource/Assets.xcassets/Color/CustomSecondaryColor.colorset/Contents.json
+++ b/Wellnest/Wellnest/Resource/Assets.xcassets/Color/CustomSecondaryColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.894",
-          "green" : "0.894",
-          "red" : "0.894"
+          "blue" : "0.953",
+          "green" : "0.953",
+          "red" : "0.953"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.894",
-          "green" : "0.894",
-          "red" : "0.894"
+          "blue" : "0.953",
+          "green" : "0.953",
+          "red" : "0.953"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## ✅ 변경사항
- 온보딩 타이틀을 일정 생성 뷰와 동일하게 네비게이션 타이틀로 수정
- 사용자 정보 뷰의 플레이스 홀더 > 투명도 0.5로 수정
- Assets의 SecondaryColor > 더 밝은 회색으로 수정(임시)
- "필수 항목" 텍스트 삭제
- "중복 선택 가능" 텍스트 > 투명도 0.5로 수정
- 온보딩 타이틀의 설명 텍스트 > 투명도 0.7로 수정
- 사용자 정보의 성별 입력 > 아이콘으로 수정
- 웰니스 목표 카드 텍스트 정렬 > 왼쪽 정렬로 수정
- 카드 선택 시 백그라운드 컬러 > FilledButton의 색상과 동일하게 수정
- 카드 아이콘 색 > 카드를 선택하지 않으면 흑백으로, 선택하면 컬러로 변경되도록 수정
- 카드 타이틀 색 > 카드를 선택하지 않으면 secondary색으로, 선택하면 흰색으로 변경되도록 수정
- FilledButton의 safeArea의 백그라운드 컬러 > 블러로 수정(임시)
- 카드 "기타", "특별히 없음"의 아이콘 수정 및 추가

## 🧪 테스트시 유의 사항
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📝 참고
- defaultShadow() 수정하기
    - 색을 옅게 하기, 버튼의 색과 통일하기 등
- 모든 입력 뷰 색상 통일하기
- 임시로 Assets의 SecondaryColor를 바꾼 거라, 색상 정하기
- FilledButton의 색상을 비활성화 상태일 땐 회색, 활성화 상태면 원래 색상(blue)로 할지
- FilledButton의 safeArea의 백그라운드 컬러 정하기
    - 1) 흰색 2) 블러 3) 투명
- 카드의 grid size를 줄일지
- 사용자 정보에서 성별에 따라 선호 활동의 아이콘의 성별도 바꿀지

## 💜 결과
<img width="160" height="325" alt="image" src="https://github.com/user-attachments/assets/c91dce05-f0a9-4d58-b587-cbeca2b00c1d" />
<img width="160" height="325" alt="image" src="https://github.com/user-attachments/assets/c1adfe22-2d8c-41e4-b1af-7eaf5bbe6a20" />
