### PR TITLE
Refactor: Core Data Service/ AnyView 수정

### DIFF
--- a/Wellnest/Wellnest/Feature/Home/View/HomeView.swift
+++ b/Wellnest/Wellnest/Feature/Home/View/HomeView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct HomeView: View {
     @Environment(\.colorScheme) var colorScheme
     
-    @StateObject private var manualScheduleVM = ManualScheduleViewModel()
+//    @StateObject private var manualScheduleVM = ManualScheduleViewModel()
+    @StateObject private var manualScheduleVM = ManualScheduleVMFactory.make()
     @StateObject private var homeVM = HomeViewModel()
     
     @State var name: String = "홍길동"
@@ -131,10 +132,13 @@ struct HomeView: View {
                             }
                         }
                     }
-                    .onAppear {
+//                    .onAppear {
+//                        manualScheduleVM.loadTodaySchedules()
+//                    }
+                    .task {
                         manualScheduleVM.loadTodaySchedules()
                     }
-                    
+
                 }
                 .padding(.bottom, Spacing.layout * 2)
             }
@@ -153,5 +157,5 @@ struct HomeView: View {
 
 #Preview {
     HomeView()
-        .environmentObject(ManualScheduleViewModel())
+        .environmentObject(ManualScheduleVMFactory.make())
 }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/Model/LocalNotifying.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/Model/LocalNotifying.swift
@@ -1,0 +1,16 @@
+//
+//  LocalNotifying.swift
+//  Wellnest
+//
+//  Created by Heejung Yang on 8/16/25.
+//
+
+import Foundation
+
+protocol LocalNotifying {
+    func scheduleLocalNotification(for schedule: ScheduleEntity)
+}
+
+// 기존 매니저를 바로 채택
+extension LocalNotiManager: LocalNotifying {}
+

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/Model/ManualScheduleInput.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/Model/ManualScheduleInput.swift
@@ -1,0 +1,24 @@
+//
+//  ManualScheduleInput.swift
+//  Wellnest
+//
+//  Created by Heejung Yang on 8/16/25.
+//
+
+import Foundation
+
+struct ScheduleInput {
+    var title: String
+    var location: String?
+    var detail: String?
+    var startDate: Date
+    var endDate: Date
+    var isAllDay: Bool
+    var backgroundColorName: String
+    var repeatRuleName: String?
+    var hasRepeatEndDate: Bool
+    var repeatEndDate: Date?
+    var alarmRuleName: String?
+    var isAlarmOn: Bool
+    var isCompleted: Bool
+}

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
@@ -14,7 +14,7 @@ struct ManualScheduleInputView: View {
     @Binding var selectedCreationType: ScheduleCreationType?
 
     // 뷰모델(서비스) — 관찰 필요 없으므로 let
-    private let editor: ScheduleEditor = {
+    private let editor: ManualScheduleInputViewModel = {
         // 필요 시 DI로 주입 가능
         return ScheduleEditorFactory.makeDefault()
     }()

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
@@ -6,17 +6,23 @@
 //
 
 import SwiftUI
+import CoreData
 
 struct ManualScheduleInputView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var selectedTab: TabBarItem
     @Binding var selectedCreationType: ScheduleCreationType?
+
+    // 뷰모델(서비스) — 관찰 필요 없으므로 let
+    private let editor: ScheduleEditor = {
+        // 필요 시 DI로 주입 가능
+        return ScheduleEditorFactory.makeDefault()
+    }()
+
+    @State private var lastSavedID: NSManagedObjectID?
+
     // 일정 제목
     @State private var title: String = ""
-
-//    @State private var selectedColorName = "accentButtonColor"
-//    @State private var selectedColor = Color("accentButtonColor")
-//    @State var showColorPickerSheet: Bool = false
     @State private var selectedColorName = "accentButtonColor"
     @State private var previewColor: Color = Color("accentButtonColor")
     @State private var showColorPickerSheet = false
@@ -68,7 +74,7 @@ struct ManualScheduleInputView: View {
     // MARK: - alarmSection
 
     // 알람 여부
-    @State private var isAlarm: Bool = false
+    @State private var isAlarmOn: Bool = false
 
     // 알람 주기
     @State private var alarmRule: AlarmRule? = nil
@@ -79,6 +85,8 @@ struct ManualScheduleInputView: View {
     @State var isKeyboardVisible: Bool = true
 
     @State private var didInit = false
+    @State private var isSaving = false
+
 
     var body: some View {
         NavigationView {
@@ -159,13 +167,13 @@ struct ManualScheduleInputView: View {
                         TagToggleSection(
                             title: "알람",
                             tags: AlarmRule.tags,
-                            isOn: $isAlarm,
+                            isOn: $isAlarmOn,
                             selectedTag: $alarmRule,
                             showDetail: false,
                             detailContent: nil
                         )
                         .padding(.bottom, 5)
-                        .onChange(of: isAlarm) { newValue in
+                        .onChange(of: isAlarmOn) { newValue in
                             UIApplication.hideKeyboard()
                         }
                         HStack {
@@ -253,30 +261,36 @@ struct ManualScheduleInputView: View {
 
 extension ManualScheduleInputView {
 
-    private func saveSchedule() {
-        let newSchedule = ScheduleEntity(context: CoreDataService.shared.context)
-        newSchedule.id = UUID()
-        newSchedule.title = title
-        newSchedule.location = location
-        newSchedule.detail = detail
-        newSchedule.startDate = startDate
-        newSchedule.endDate = endDate
-        newSchedule.isAllDay = isAllDay as NSNumber
-        newSchedule.isCompleted = false
-        newSchedule.backgroundColor = selectedColorName
-        newSchedule.repeatRule = selectedRepeatRule?.name
-        newSchedule.hasRepeatEndDate = hasRepeatEndDate
-        newSchedule.repeatEndDate = repeatEndDate
-        newSchedule.alarm = alarmRule?.name
-        newSchedule.scheduleType = "custom"
-        newSchedule.createdAt = Date()
-        newSchedule.updatedAt = Date()
+    @MainActor
+    func saveSchedule() {
+        Task { await saveSchedule() } // 위의 async 버전을 재사용
+    }
 
-        print(newSchedule)
-        try? CoreDataService.shared.saveContext()
-        
-        if isAlarm {
-            LocalNotiManager.shared.scheduleLocalNotification(for: newSchedule)
+    @MainActor
+    func saveSchedule() async {
+        let input = ScheduleInput(
+            title: title,
+            location: location,
+            detail: detail,
+            startDate: startDate,
+            endDate: endDate,
+            isAllDay: isAllDay,
+            backgroundColorName: selectedColorName,
+            repeatRuleName: selectedRepeatRule?.name,
+            hasRepeatEndDate: hasRepeatEndDate,
+            repeatEndDate: repeatEndDate,
+            alarmRuleName: alarmRule?.name,
+            isAlarmOn: isAlarmOn,
+            isCompleted: false
+        )
+        Task {
+            do {
+                let id = try await editor.saveSchedule(input)
+                lastSavedID = id
+            } catch {
+                print(error.localizedDescription)
+            }
+            isSaving = false
         }
     }
 }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/ManualScheduleInputView.swift
@@ -150,16 +150,10 @@ struct ManualScheduleInputView: View {
                             isOn: $isRepeated,
                             selectedTag: $selectedRepeatRule,
                             showDetail: selectedRepeatRule != nil,
-                            detailContent: {
-                                AnyView(
-                                    EndDateSelectorView(endDate: $repeatEndDate)
-                                )
-                            },
-                            onTagTap: { _ in
-                                UIApplication.hideKeyboard()
-                                isKeyboardVisible = false
-                            }
-                        )
+                            onTagTap: { _ in isKeyboardVisible = false }
+                        ) {
+                            EndDateSelectorView(endDate: $repeatEndDate)
+                        }
                         .padding(.bottom, 5)
                         .onChange(of: isRepeated) { newValue in
                             UIApplication.hideKeyboard()
@@ -168,9 +162,7 @@ struct ManualScheduleInputView: View {
                             title: "알람",
                             tags: AlarmRule.tags,
                             isOn: $isAlarmOn,
-                            selectedTag: $alarmRule,
-                            showDetail: false,
-                            detailContent: nil
+                            selectedTag: $alarmRule
                         )
                         .padding(.bottom, 5)
                         .onChange(of: isAlarmOn) { newValue in
@@ -202,8 +194,8 @@ struct ManualScheduleInputView: View {
                         Spacer()
                     }
                     .padding()
-
                 }
+                .padding(.bottom, 30)
                 .onDisappear {
                     UIApplication.hideKeyboard()
                 }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/SubView/TagToggleSection.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/View/SubView/TagToggleSection.swift
@@ -7,25 +7,42 @@
 
 import SwiftUI
 
-struct TagToggleSection<Model: TagModel>: View {
+// 기본: Detail 뷰 제네릭
+struct TagToggleSection<Model: TagModel & Equatable, Detail: View>: View {
     let title: String
     let tags: [Model]
     @Binding var isOn: Bool
     @Binding var selectedTag: Model?
-    
+
     let showDetail: Bool
-    let detailContent: (() -> AnyView)?
+    private let detailContent: () -> Detail
     var onTagTap: ((Model) -> Void)? = nil
+
+    init(
+        title: String,
+        tags: [Model],
+        isOn: Binding<Bool>,
+        selectedTag: Binding<Model?>,
+        showDetail: Bool = false,
+        onTagTap: ((Model) -> Void)? = nil,
+        @ViewBuilder detailContent: @escaping () -> Detail
+    ) {
+        self.title = title
+        self.tags = tags
+        self._isOn = isOn
+        self._selectedTag = selectedTag
+        self.showDetail = showDetail
+        self.onTagTap = onTagTap
+        self.detailContent = detailContent
+    }
 
     var body: some View {
         VStack(alignment: .leading) {
-
             Toggle(isOn: $isOn) {
                 Text(title)
                     .font(.headline)
                     .fontWeight(.semibold)
             }
-
 
             if isOn {
                 HStack {
@@ -38,11 +55,33 @@ struct TagToggleSection<Model: TagModel>: View {
                     }
                 }
 
-                if showDetail, let detail = detailContent {
-                    detail()
+                if showDetail {
+                    detailContent()
                 }
             }
         }
+    }
+}
+
+// EmptyView를 쓰는 편의 생성자 (detailContent 생략 가능)
+extension TagToggleSection where Detail == EmptyView {
+    init(
+        title: String,
+        tags: [Model],
+        isOn: Binding<Bool>,
+        selectedTag: Binding<Model?>,
+        showDetail: Bool = false,
+        onTagTap: ((Model) -> Void)? = nil
+    ) {
+        self.init(
+            title: title,
+            tags: tags,
+            isOn: isOn,
+            selectedTag: selectedTag,
+            showDetail: showDetail,
+            onTagTap: onTagTap,
+            detailContent: { EmptyView() }
+        )
     }
 }
 

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleInputViewModel.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleInputViewModel.swift
@@ -7,7 +7,7 @@
 
 import CoreData
 
-final class ScheduleEditor {
+final class ManualScheduleInputViewModel {
     private let store: CoreDataStore            // actor (백그라운드 CRUD)
     private let viewContext: NSManagedObjectContext
     private let notifier: LocalNotifying
@@ -56,12 +56,12 @@ final class ScheduleEditor {
 }
 
 enum ScheduleEditorFactory {
-    static func makeDefault() -> ScheduleEditor {
+    static func makeDefault() -> ManualScheduleInputViewModel {
         let container = CoreDataStack.shared.container
         let viewContext = container.viewContext
         let store = CoreDataStore(container: container) // actor
         let notifier: LocalNotifying = LocalNotiManager.shared
-        return ScheduleEditor(store: store,
+        return ManualScheduleInputViewModel(store: store,
                               viewContext: viewContext,
                               notifier: notifier)
     }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleInputViewModel.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleInputViewModel.swift
@@ -47,7 +47,7 @@ final class ManualScheduleInputViewModel {
         // 2) 알림 필요 시 MainActor에서 바인딩 후 예약
         if input.isAlarmOn {
             try await MainActor.run {
-                let obj = try viewContext.existingObject(with: id) as! ScheduleEntity
+                guard let obj = try viewContext.existingObject(with: id) as? ScheduleEntity else { return }
                 notifier.scheduleLocalNotification(for: obj)
             }
         }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleViewModel.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleViewModel.swift
@@ -10,9 +10,20 @@ import CoreData
 
 final class ManualScheduleViewModel: ObservableObject {
     @Published var todaySchedules: [ScheduleItem] = []
-    
+
+    private let store: CoreDataStore
+
+    init(store: CoreDataStore) {
+        self.store = store
+    }
+
+    // MARK: - Load
     /// 오늘 날짜에 해당하는 일정 목록 조회하여 todaySchedules에 초기화
     func loadTodaySchedules() {
+        Task { await loadTodaySchedules() } // 위의 async 버전을 재사용
+    }
+
+    private func loadTodaySchedules() async {
         let (now, startOfTomorrow) = Self.todayBounds()
 
         let predicate = NSPredicate(
@@ -20,55 +31,84 @@ final class ManualScheduleViewModel: ObservableObject {
             now as NSDate,
             startOfTomorrow as NSDate
         )
-
-
         let sort = NSSortDescriptor(keyPath: \ScheduleEntity.startDate, ascending: true)
 
         do {
-            let entities = try CoreDataService.shared.fetch(
+            // actor 내부에서 Entity -> DTO 변환
+            let items = try await store.fetchDTOs(
                 ScheduleEntity.self,
                 predicate: predicate,
                 sortDescriptors: [sort]
-            )
+            ) { e in
+                ScheduleItem(
+                    id: e.id ?? UUID(),
+                    title: e.title ?? "",
+                    startDate: e.startDate ?? Date(),
+                    endDate: e.endDate ?? Date(),
+                    createdAt: e.createdAt ?? Date(),
+                    updatedAt: e.updatedAt ?? Date(),
+                    backgroundColor: e.backgroundColor ?? "",
+                    isAllDay: e.isAllDay?.boolValue ?? false,
+                    repeatRule: e.repeatRule,
+                    hasRepeatEndDate: e.hasRepeatEndDate,
+                    repeatEndDate: e.repeatEndDate,
+                    isCompleted: e.isCompleted?.boolValue ?? false
+                )
+            }
 
-            todaySchedules = entities.map(Self.mapToItem)
+            self.todaySchedules = items
         } catch {
             print("📛 일정 로드 실패:", error.localizedDescription)
         }
     }
-    
-    /// 일정 완료 상태 변경
-    /// - Parameter item: 완료 상태를 변경하려는 ScheduleItem
+
+    // MARK: - Update Completed
+    /// 일정 완료 상태 토글
     func updateCompleted(item: ScheduleItem) {
-        guard let entity = fetchSchedule(id: item.id) else {
-            print("📛 대상 일정 entity fetch 실패")
-            return
-        }
-        
+        Task { await updateCompleted(item: item) } // 위의 async 버전을 재사용
+    }
+
+    private func updateCompleted(item: ScheduleItem) async {
+        // UUID로 해당 엔티티의 ObjectID 조회
+        let predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
         do {
-            let current = entity.isCompleted?.boolValue ?? false
-            let newValue = !current
-            
-            try CoreDataService.shared.update(entity, by: \ScheduleEntity.isCompleted, to: NSNumber(value: newValue))
-            if let index = todaySchedules.firstIndex(where: { $0.id == item.id }) {
-                todaySchedules[index].isCompleted.toggle()
+            let ids = try await store.fetchIDs(ScheduleEntity.self, predicate: predicate, sortDescriptors: nil, fetchLimit: 1)
+            guard let objectID = ids.first else {
+                print("📛 대상 일정 ID 조회 실패")
+                return
+            }
+
+            try await store.update(id: objectID) { (e: ScheduleEntity) in
+                let current = e.isCompleted?.boolValue ?? false
+                e.isCompleted = NSNumber(value: !current)
+                e.updatedAt = Date()
+            }
+
+            if let idx = todaySchedules.firstIndex(where: { $0.id == item.id }) {
+                todaySchedules[idx].isCompleted.toggle()
             }
         } catch {
-            print("❌ 일정 삭제 실패:", error.localizedDescription)
+            print("❌ 일정 완료 토글 실패:", error.localizedDescription)
         }
     }
-    
-    /// 일정 삭제
-    /// - Parameter item: 삭제하려는 일정 ScheduleItem
-    func deleteSchedule(item: ScheduleItem) {
-        guard let entity = fetchSchedule(id: item.id) else {
-            print("📛 대상 일정 entity fetch 실패")
-            return
-        }
 
+    // MARK: - Delete
+    /// 일정 삭제
+    func deleteSchedule(item: ScheduleItem) {
+        Task { await deleteSchedule(item: item) } // 위의 async 버전을 재사용
+    }
+
+    func deleteSchedule(item: ScheduleItem) async {
+        let predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
         do {
-            try CoreDataService.shared.delete(entity)
-            self.todaySchedules.removeAll { $0.id == item.id }
+            let ids = try await store.fetchIDs(ScheduleEntity.self, predicate: predicate, sortDescriptors: nil, fetchLimit: 1)
+            guard let objectID = ids.first else {
+                print("📛 대상 일정 ID 조회 실패")
+                return
+            }
+
+            try await store.delete(id: objectID)
+            todaySchedules.removeAll { $0.id == item.id }
         } catch {
             print("❌ 일정 삭제 실패:", error.localizedDescription)
         }
@@ -78,45 +118,16 @@ final class ManualScheduleViewModel: ObservableObject {
     private static func todayBounds() -> (Date, Date) {
         let now = Date()
         let calendar = Calendar.current
-
         let startOfToday = calendar.startOfDay(for: now)
         let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday)!
-
         return (now, startOfTomorrow)
     }
+}
 
-    /// ScheduleItem 객체 생성
-    /// - Parameter entity: ScheduleItem 객체로 생성할 데이터로 ScheduleEntity를 파라미터로 받음
-    /// - Returns: 생성된 ScheduleItem 리턴
-    private static func mapToItem(entity: ScheduleEntity) -> ScheduleItem {
-        ScheduleItem(
-            id: entity.id ?? UUID(),
-            title: entity.title ?? "",
-            startDate: entity.startDate ?? Date(),
-            endDate: entity.endDate ?? Date(),
-            createdAt: entity.createdAt ?? Date(),
-            updatedAt: entity.updatedAt ?? Date(),
-            backgroundColor: entity.backgroundColor ?? "",
-            isAllDay: entity.isAllDay?.boolValue ?? false,
-            repeatRule: entity.repeatRule ?? nil,
-            hasRepeatEndDate: entity.hasRepeatEndDate,
-            repeatEndDate: entity.repeatEndDate,
-            isCompleted: entity.isCompleted?.boolValue ?? false
-        )
-    }
-    
-    /// id를 활용하여 일정 조회
-    /// - Parameter id: 조회하려는 id
-    /// - Returns: 조회한 ScheduleEntity
-    private func fetchSchedule(id: ScheduleItem.ID) -> ScheduleEntity? {
-        let predicate = NSPredicate(format: "id == %@", id as CVarArg)
-        
-        do {
-            let entity = try CoreDataService.shared.fetch(ScheduleEntity.self, predicate: predicate)
-            return entity.first
-        } catch {
-            print("📛 대상 일정 fetch 실패:", error.localizedDescription)
-            return nil
-        }
+enum ManualScheduleVMFactory {
+    static func make() -> ManualScheduleViewModel {
+        let container = CoreDataStack.shared.container
+        let store = CoreDataStore(container: container)
+        return ManualScheduleViewModel(store: store)
     }
 }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleViewModel.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ManualScheduleViewModel.swift
@@ -56,7 +56,9 @@ final class ManualScheduleViewModel: ObservableObject {
                 )
             }
 
-            self.todaySchedules = items
+            await MainActor.run {
+                self.todaySchedules = items
+            }
         } catch {
             print("📛 일정 로드 실패:", error.localizedDescription)
         }
@@ -83,9 +85,10 @@ final class ManualScheduleViewModel: ObservableObject {
                 e.isCompleted = NSNumber(value: !current)
                 e.updatedAt = Date()
             }
-
-            if let idx = todaySchedules.firstIndex(where: { $0.id == item.id }) {
-                todaySchedules[idx].isCompleted.toggle()
+            await MainActor.run {
+                if let idx = self.todaySchedules.firstIndex(where: { $0.id == item.id }) {
+                    self.todaySchedules[idx].isCompleted.toggle()
+                }
             }
         } catch {
             print("❌ 일정 완료 토글 실패:", error.localizedDescription)
@@ -108,7 +111,9 @@ final class ManualScheduleViewModel: ObservableObject {
             }
 
             try await store.delete(id: objectID)
-            todaySchedules.removeAll { $0.id == item.id }
+            await MainActor.run {
+                self.todaySchedules.removeAll { $0.id == item.id }
+            }
         } catch {
             print("❌ 일정 삭제 실패:", error.localizedDescription)
         }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ScheduleEditor.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/Manual/ViewModel/ScheduleEditor.swift
@@ -1,0 +1,68 @@
+//
+//  ManualScheduleInputViewModel.swift
+//  Wellnest
+//
+//  Created by Heejung Yang on 8/16/25.
+//
+
+import CoreData
+
+final class ScheduleEditor {
+    private let store: CoreDataStore            // actor (백그라운드 CRUD)
+    private let viewContext: NSManagedObjectContext
+    private let notifier: LocalNotifying
+
+    init(store: CoreDataStore,
+         viewContext: NSManagedObjectContext,
+         notifier: LocalNotifying) {
+        self.store = store
+        self.viewContext = viewContext
+        self.notifier = notifier
+    }
+
+    /// 저장 + (옵션) 알림 예약. 성공 시 생성된 ObjectID 반환
+    @discardableResult
+    func saveSchedule(_ input: ScheduleInput) async throws -> NSManagedObjectID {
+        // 1) 백그라운드 컨텍스트에서 생성
+        let id = try await store.create(ScheduleEntity.self) { e in
+            e.id = UUID()
+            e.title = input.title
+            e.location = input.location
+            e.detail = input.detail
+            e.startDate = input.startDate
+            e.endDate = input.endDate
+            e.isAllDay = input.isAllDay as NSNumber
+            e.isCompleted = input.isCompleted as NSNumber
+            e.backgroundColor = input.backgroundColorName
+            e.repeatRule = input.repeatRuleName
+            e.hasRepeatEndDate = input.hasRepeatEndDate
+            e.repeatEndDate = input.repeatEndDate
+            e.alarm = input.alarmRuleName
+            e.scheduleType = "custom"
+            e.createdAt = Date()
+            e.updatedAt = Date()
+            print(e)
+        }
+
+        // 2) 알림 필요 시 MainActor에서 바인딩 후 예약
+        if input.isAlarmOn {
+            try await MainActor.run {
+                let obj = try viewContext.existingObject(with: id) as! ScheduleEntity
+                notifier.scheduleLocalNotification(for: obj)
+            }
+        }
+        return id
+    }
+}
+
+enum ScheduleEditorFactory {
+    static func makeDefault() -> ScheduleEditor {
+        let container = CoreDataStack.shared.container
+        let viewContext = container.viewContext
+        let store = CoreDataStore(container: container) // actor
+        let notifier: LocalNotifying = LocalNotiManager.shared
+        return ScheduleEditor(store: store,
+                              viewContext: viewContext,
+                              notifier: notifier)
+    }
+}

--- a/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataError.swift
+++ b/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataError.swift
@@ -18,4 +18,6 @@ enum CoreDataError: Error {
 
     /// 데이터를 삭제하는 도중 발생한 오류
     case deleteError(any Error)
+
+    case castFailed(String)
 }

--- a/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataStack.swift
+++ b/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataStack.swift
@@ -1,0 +1,32 @@
+//
+//  CoreDataStack.swift
+//  Wellnest
+//
+//  Created by Heejung Yang on 8/16/25.
+//
+
+import CoreData
+
+public final class CoreDataStack {
+    public static let shared = CoreDataStack()
+    private init() {}
+
+    public lazy var container: NSPersistentContainer = {
+        let c = NSPersistentContainer(name: "Wellnest")
+        c.loadPersistentStores { _, error in
+            if let error = error { fatalError("Core Data load error: \(error)") }
+        }
+        c.viewContext.automaticallyMergesChangesFromParent = true
+        c.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return c
+    }()
+
+    public var viewContext: NSManagedObjectContext { container.viewContext }
+
+    @discardableResult
+    public func saveViewContextIfNeeded() throws -> Bool {
+        guard viewContext.hasChanges else { return false }
+        try viewContext.save()
+        return true
+    }
+}

--- a/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataStore.swift
+++ b/Wellnest/Wellnest/Shared/Persistence/CoreData/CoreDataStore.swift
@@ -1,0 +1,129 @@
+//
+//  CoreDataStore.swift
+//  Wellnest
+//
+//  Created by Heejung Yang on 8/16/25.
+//
+
+import CoreData
+
+public actor CoreDataStore {
+
+    private let container: NSPersistentContainer
+    private let ctx: NSManagedObjectContext
+
+    public init(container: NSPersistentContainer = CoreDataStack.shared.container) {
+        self.container = container
+        self.ctx = container.newBackgroundContext()
+        self.ctx.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+
+    // MARK: - Create
+    @discardableResult
+    public func create<Entity: NSManagedObject>(
+        _ type: Entity.Type,
+        configure: @escaping (Entity) -> Void
+    ) async throws -> NSManagedObjectID {
+        let context = self.ctx
+        return try await context.perform {
+            let name = String(describing: Entity.self)
+            guard let obj = NSEntityDescription.insertNewObject(forEntityName: name, into: context) as? Entity else {
+                throw CoreDataError.castFailed(name)
+            }
+            configure(obj)
+            try context.save()
+            return obj.objectID
+        }
+    }
+
+    // MARK: - Fetch (IDs)
+    public func fetchIDs<Entity: NSManagedObject>(
+        _ type: Entity.Type,
+        predicate: NSPredicate? = nil,
+        sortDescriptors: [NSSortDescriptor]? = nil,
+        fetchLimit: Int = 0
+    ) async throws -> [NSManagedObjectID] {
+        let context = self.ctx
+        return try await context.perform {
+            let req = NSFetchRequest<NSManagedObjectID>(entityName: String(describing: Entity.self))
+            req.predicate = predicate
+            req.sortDescriptors = sortDescriptors
+            req.resultType = .managedObjectIDResultType
+            if fetchLimit > 0 { req.fetchLimit = fetchLimit }
+            do {
+                return try context.fetch(req)
+            } catch {
+                throw CoreDataError.readError(error)
+            }
+        }
+    }
+
+    // MARK: - Fetch (DTO 변환)
+    public func fetchDTOs<Entity: NSManagedObject, DTO>(
+        _ type: Entity.Type,
+        predicate: NSPredicate? = nil,
+        sortDescriptors: [NSSortDescriptor]? = nil,
+        map: @escaping (Entity) -> DTO
+    ) async throws -> [DTO] {
+        let context = self.ctx
+        return try await context.perform {
+            let req = NSFetchRequest<Entity>(entityName: String(describing: Entity.self))
+            req.predicate = predicate
+            req.sortDescriptors = sortDescriptors
+            do {
+                let objs = try context.fetch(req)
+                return objs.map(map)
+            } catch {
+                throw CoreDataError.readError(error)
+            }
+        }
+    }
+
+    // MARK: - Update (by ID)
+    public func update<Entity: NSManagedObject>(
+        id: NSManagedObjectID,
+        apply changes: @escaping (Entity) -> Void
+    ) async throws {
+        let context = self.ctx
+        try await context.perform {
+            guard let obj = try? context.existingObject(with: id) as? Entity else { return }
+            changes(obj)
+            do { try context.save() } catch { throw CoreDataError.saveError(error) }
+        }
+    }
+
+    // MARK: - Delete (by ID)
+    public func delete(id: NSManagedObjectID) async throws {
+        try await ctx.perform {
+            let context = self.ctx
+            if let obj = try? context.existingObject(with: id) {
+                context.delete(obj)
+                do { try context.save() } catch { throw CoreDataError.deleteError(error) }
+            }
+        }
+    }
+
+    // MARK: - Delete All
+    public func deleteAll<Entity: NSManagedObject>(_ type: Entity.Type) async throws {
+        let context = self.ctx
+        let container = self.container
+        try await context.perform {
+            let fetch = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: Entity.self))
+            let del = NSBatchDeleteRequest(fetchRequest: fetch)
+            del.resultType = .resultTypeObjectIDs
+            do {
+                let result = try context.execute(del) as? NSBatchDeleteResult
+                if let ids = result?.result as? [NSManagedObjectID] {
+                    // UI 컨텍스트에 변경 사항 머지
+                    NSManagedObjectContext.mergeChanges(
+                        fromRemoteContextSave: [NSDeletedObjectsKey: ids],
+                        into: [container.viewContext]
+                    )
+                }
+                try context.save()
+            } catch {
+                throw CoreDataError.deleteError(error)
+            }
+        }
+    }
+}

--- a/Wellnest/Wellnest/Shared/Service/LocationManger.swift
+++ b/Wellnest/Wellnest/Shared/Service/LocationManger.swift
@@ -16,7 +16,6 @@ enum LocationError: Error {
     case unableToFindLocation
 }
 
-@MainActor
 final class LocationManager: NSObject, ObservableObject {
     @Published var lastLocation: CLLocation?
     @Published var error: LocationError?


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## ✅ 변경사항
- 백그라운드 처리 및 데이터 동시 접근 안정성을 위해 기존의 싱글톤이었던 ```CoreDataService``` 클래스를 ```CoreDataStore``` Actor로 변경했습니다.
따라서 ```HomeView```에 ```manualScheduleVM```관련 코드 수정이 발생했습니다. 주용님(@twoweeks-y) 확인 부탁드려요.
- ```viewContext```가 메인 큐 전용(UI 컨텍스트)이기 때문에 관련 코드는 ```CoreDataStack```으로 분리했습니다.
- ```TagToggleSection```detailContent 속성에서 파라미터로 AnyView 대신 opaque타입을 받도록 수정했습니다.(opaque 타입은 제네릭 제약(Detail: View)으로 API가 기대하는 뷰를 컴파일 타임에 강하게 보장하기 때문.)

## 🧪 테스트시 유의 사항
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📝 참고

## 💜 결과
스크린샷이 있다면 첨부해주세요.
