### PR TITLE
fix/AI 일정 생성시 기본색 통일

### DIFF
--- a/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/View/AIScheduleInputView.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/View/AIScheduleInputView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AIScheduleInputView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     @Binding var selectedTab: TabBarItem
     @Binding var selectedCreationType: ScheduleCreationType?
     @StateObject private var viewModel = AIScheduleViewModel()
@@ -53,10 +54,24 @@ struct AIScheduleInputView: View {
                 )
             }
             .safeAreaInset(edge: .bottom) {
-                generateButton
-                    .padding()
-                    .background(.white)
-                    .ignoresSafeArea(.keyboard, edges: .bottom)
+                VStack(spacing: 0) {
+                    // 버튼 위로 덮일 페이드
+                    LinearGradient(
+                        gradient: Gradient(stops: [
+                            .init(color: colorScheme == .dark ? .black.opacity(0.0) : .white.opacity(0.0), location: 0.0),
+                            .init(color: colorScheme == .dark ? .black : .white, location: 1.0),
+                        ]),
+                        startPoint: .top, endPoint: .bottom
+                    )
+                    .frame(height: 28)
+                    
+                    generateButton
+                        .padding()
+                        .background(colorScheme == .dark
+                                    ? Color.black.ignoresSafeArea(edges: .bottom)
+                                    : Color.white.ignoresSafeArea(edges: .bottom))
+                }
+                .ignoresSafeArea(.keyboard, edges: .bottom)
             }
         }
     }

--- a/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/View/AIScheduleResultView.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/View/AIScheduleResultView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AIScheduleResultView: View {
     @ObservedObject var viewModel: AIScheduleViewModel
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     @Binding var selectedTab: TabBarItem
     @Binding var selectedCreationType: ScheduleCreationType?
     let parentDismiss: DismissAction
@@ -68,10 +69,24 @@ struct AIScheduleResultView: View {
             }
             .safeAreaInset(edge: .bottom) {
                 if viewModel.currentViewState == .content, let _ = viewModel.healthPlan {
-                    saveButtonsSection
-                        .padding()
-                        .background(.white)
-                        .ignoresSafeArea(.keyboard, edges: .bottom)
+                    VStack(spacing: 0) {
+                        // 버튼 위로 덮일 페이드
+                        LinearGradient(
+                            gradient: Gradient(stops: [
+                                .init(color: colorScheme == .dark ? .black.opacity(0.0) : .white.opacity(0.0), location: 0.0),
+                                .init(color: colorScheme == .dark ? .black : .white, location: 1.0),
+                            ]),
+                            startPoint: .top, endPoint: .bottom
+                        )
+                        .frame(height: 28)
+                        
+                        saveButtonsSection
+                            .padding()
+                            .background(colorScheme == .dark
+                                        ? Color.black.ignoresSafeArea(edges: .bottom)
+                                        : Color.white.ignoresSafeArea(edges: .bottom))
+                    }
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
                 }
             }
             .alert("저장 완료", isPresented: $viewModel.saveSuccess) {

--- a/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/ViewModel/AIScheduleViewModel.swift
+++ b/Wellnest/Wellnest/Feature/ScheduleInput/AlanAI/ViewModel/AIScheduleViewModel.swift
@@ -379,6 +379,7 @@ final class AIScheduleViewModel: ObservableObject {
             newSchedule.repeatEndDate = nil
             newSchedule.alarm = nil
             newSchedule.scheduleType = "ai_generated"
+            newSchedule.backgroundColor = "#007AFF"
             newSchedule.createdAt = Date()
             newSchedule.updatedAt = Date()
         }
@@ -494,6 +495,7 @@ final class AIScheduleViewModel: ObservableObject {
                 newSchedule.repeatEndDate = nil
                 newSchedule.alarm = nil
                 newSchedule.scheduleType = "ai_generated"
+                newSchedule.backgroundColor = "#007AFF"
                 newSchedule.createdAt = Date()
                 newSchedule.updatedAt = Date()
                 newSchedule.eventIdentifier = nil
@@ -552,6 +554,7 @@ final class AIScheduleViewModel: ObservableObject {
                 newSchedule.repeatEndDate = routineEndDate
                 newSchedule.alarm = nil
                 newSchedule.scheduleType = "ai_generated"
+                newSchedule.backgroundColor = "#007AFF"
                 newSchedule.createdAt = Date()
                 newSchedule.updatedAt = Date()
                 newSchedule.eventIdentifier = nil


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
AIScheduleViewModel에서 일정 생성 시 backgroundCorlor를 지정해 PlanView에서 플랜이 나오지 않는 버그와 기본 색상 불일치 이슈를 수정했습니다.

<!---- Resolves: #(Isuue Number) -->

## ✅ 변경사항
- 일정을 생성할 때 기본 색상을 추가해 기본색 통일
- 일정 생성 및 저장 화면의 하단 Safe Area 배경 DarkMode 대응

## 🧪 테스트시 유의 사항
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📝 참고

## 💜 결과
<div style="display: flex; justify-content: center; flex-wrap: wrap; gap: 16px; max-width: 640px; margin: 0 auto;">
  <img src="https://github.com/user-attachments/assets/44054e5d-f06b-4e5d-8ef0-8424f2f2b055" alt="image1" width="300" />
  <img src="https://github.com/user-attachments/assets/eca873ab-5ce9-4e07-911a-2c9ff62ce0a6" alt="image2" width="300" />
  <img src="https://github.com/user-attachments/assets/c4db1891-f03a-4d81-9362-bda57b7ebfcd" alt="image3" width="300" />
  <img src="https://github.com/user-attachments/assets/bd0dc7f7-8d97-43c7-b641-581cc478f7e7" alt="image4" width="300" />
</div>