### PR TITLE
분석탭 남은 작업 처리

### DIFF
--- a/Wellnest/Wellnest/Feature/Analytics/Model/ExerciseData.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/Model/ExerciseData.swift
@@ -22,3 +22,13 @@ struct ExerciseData {
     let weeklyCaloriesChange: Int
     let monthlyCaloriesChange: Int
 }
+
+extension ExerciseData {
+    var defaultTodaySteps: Int {
+        return 7203
+    }
+    
+    var defaultTodayCalories: Int {
+        return 2120
+    }
+}

--- a/Wellnest/Wellnest/Feature/Analytics/Model/SleepData.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/Model/SleepData.swift
@@ -22,3 +22,9 @@ struct SleepData {
     let weeklyQualityChange: Int
     let monthlyQualityChange: Int
 }
+
+extension SleepData {
+    var defaultSleepDuration: TimeInterval {
+        return 7 * 3600
+    }
+}

--- a/Wellnest/Wellnest/Feature/Analytics/View/AnalyticsView.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/AnalyticsView.swift
@@ -59,7 +59,6 @@ struct AnalyticsView: View {
     private var iPhoneLayout: some View {
         VStack(spacing: Spacing.layout) {
             ScheduleProgressView()
-//            AIInsightCardView(insight: viewModel.healthData.aiInsight)
             AIInsightView()
             ExerciseStatChartCardView(exerciseData: viewModel.healthData.exercise)
             SleepStatChartCardView(sleepData: viewModel.healthData.sleep)
@@ -80,7 +79,6 @@ struct AnalyticsView: View {
                     ExerciseStatChartCardView(exerciseData: viewModel.healthData.exercise)
                 }
                 VStack(alignment: .leading, spacing: Spacing.layout) {
-//                    AIInsightCardView(insight: viewModel.healthData.aiInsight)
                     AIInsightView()
                     SleepStatChartCardView(sleepData: viewModel.healthData.sleep)
                 }

--- a/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightView.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightView.swift
@@ -36,7 +36,7 @@ struct AIInsightView: View {
                             .font(.footnote)
                             .foregroundColor(.secondary)
                         Text(viewModel.insightText ?? "")
-                            .font(.caption)
+                            .font(.callout)
                             .fontWeight(.medium)
                             .fixedSize(horizontal: false, vertical: true)
                     }

--- a/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightView.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightView.swift
@@ -9,12 +9,8 @@ import SwiftUI
 
 struct AIInsightView: View {
     @Environment(\.colorScheme) private var colorScheme
-//    let insight: AIInsightData
     @StateObject private var viewModel: AIInsightViewModel
     
-//    @StateObject private var viewModel: ScheduleProgressViewModel
-    
-    //init(context: NSManagedObjectContext) {
     init() {
         _viewModel = StateObject(wrappedValue: AIInsightViewModel())
     }

--- a/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightViewModel.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightViewModel.swift
@@ -19,9 +19,9 @@ final class AIInsightViewModel: ObservableObject {
     }
     
     func loadAIInsight() async {
-//        let healthData = try? await loadExerciseData()
-        //let result = await fetchAIInsight(input: healthData)
-        let result = await fetchAIInsight(input: nil)
+        let healthData = try? await loadExerciseData()
+        let result = await fetchAIInsight(input: healthData)
+//        let result = await fetchAIInsight(input: nil)
         
         await MainActor.run {
             self.insightText = result
@@ -46,7 +46,7 @@ private extension AIInsightViewModel {
         return """
                 \(input?.AIPrompt)
                 
-                위 데이터를 참조해서 내가 오늘 어떻게 건강관리를 하면 좋을지 한 문장으로 만들어줘.
+                위 데이터를 참조해서 내가 오늘 어떻게 건강관리를 하면 좋을지 40자 제한, 한 문장으로 만들어줘.
                 응원하는 얘기도 좋아. 만약 데이터가 없으면 니가 추천해 주고 싶은 건강관리 말을 만들어줘. 
                 """
     }

--- a/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightViewModel.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/SubView/AIInsightView/AIInsightViewModel.swift
@@ -19,8 +19,9 @@ final class AIInsightViewModel: ObservableObject {
     }
     
     func loadAIInsight() async {
-        let healthData = await loadExerciseData()
-        let result = await fetchAIInsight()
+//        let healthData = try? await loadExerciseData()
+        //let result = await fetchAIInsight(input: healthData)
+        let result = await fetchAIInsight(input: nil)
         
         await MainActor.run {
             self.insightText = result
@@ -29,55 +30,67 @@ final class AIInsightViewModel: ObservableObject {
 }
 
 private extension AIInsightViewModel {
-    func fetchAIInsight() async -> AttributedString? {
+    func fetchAIInsight(input: ExerciseData?) async -> AttributedString? {
         do {
-            //            guard let userInfo else { return "" }
             let aiService = AIServiceProxy()
-            let result = try await aiService.request(prompt: Self.insightPrompt(user: nil))
-            print("##### ai result: \(result)")
+            let result = try await aiService.request(prompt: Self.insightPrompt(input: input))
             return try? AttributedString(markdown: result.content)
         } catch {
-            print("오늘의 한마디 요청 실패:", error.localizedDescription)
-            return "AI 응답을 가져올 수 없습니다."
+            var text = AttributedString("AI 응답을 가져올 수 없습니다.")
+            text.foregroundColor = .red
+            return text
         }
     }
     
-    static func insightPrompt(user: UserEntity?) -> String {
+    static func insightPrompt(input: ExerciseData?) -> String {
         return """
-                iOS 개발자의 미래는 어떻다고 생각해? 
-                중요1: 반드시 간단한 한 문장으로
-                중요2: 반드시 해당 한글과 영어를 제외한 문자는 제외시켜줘. *도 제외시켜줘
-                중요3: 형식은 JSON 형식 아님
+                \(input?.AIPrompt)
+                
+                위 데이터를 참조해서 내가 오늘 어떻게 건강관리를 하면 좋을지 한 문장으로 만들어줘.
+                응원하는 얘기도 좋아. 만약 데이터가 없으면 니가 추천해 주고 싶은 건강관리 말을 만들어줘. 
                 """
     }
 }
+
+private extension ExerciseData {
+    var AIPrompt: String {
+     return """
+         운동 데이터 AI 프롬프트
+         사용자 운동 데이터:
+         - 하루 평균 걸음 수: \(averageSteps)보
+         - 걸음 수 변화량: \(stepsChange)
+         - 하루 평균 칼로리 소모: \(averageCalories)kcal
+         - 칼로리 변화량: \(caloriesChange)
+         - 주간 걸음 수 데이터: \(weeklySteps)
+         - 월간 걸음 수 데이터: \(monthlySteps)
+         변화율 데이터:
+         - 일일 걸음 수 변화율: \(dailyStepsChange)%
+         - 주간 걸음 수 변화율: \(weeklyStepsChange)%
+         - 월간 걸음 수 변화율: \(monthlyStepsChange)%
+         - 일일 칼로리 변화율: \(dailyCaloriesChange)%
+         - 주간 칼로리 변화율: \(weeklyCaloriesChange)%
+         - 월간 칼로리 변화율: \(monthlyCaloriesChange)%
+         """
+    }
+}
+
     
 private extension AIInsightViewModel {
-    func loadExerciseData() async -> ExerciseData {
+    func loadExerciseData() async throws -> ExerciseData {
         print("❤️ 운동 데이터 로드 시작")
 
         guard HKHealthStore.isHealthDataAvailable() else {
-            print("❤️ HealthKit을 사용할 수 없음")
-            return ExerciseData(
-                averageSteps: 0, stepsChange: 0, averageCalories: 0, caloriesChange: 0,
-                weeklySteps: Array(repeating: 0, count: 7), monthlySteps: Array(repeating: 0, count: 8),
-                dailyStepsChange: 0, weeklyStepsChange: 0, monthlyStepsChange: 0,
-                dailyCaloriesChange: 0, weeklyCaloriesChange: 0, monthlyCaloriesChange: 0
-            )
+            print("HealthKit을 사용할 수 없음")
+            throw HealthKitError.notAvailable
         }
 
         let authCheck = await healthManager.finalAuthSnapshot()
-        print("❤️ HealthKit 권한 상태:")
-        print("❤️ - 누락된 권한: \(authCheck.missingCore)")
+        print("HealthKit 권한 상태:")
+        print(" - 누락된 권한: \(authCheck.missingCore)")
 
         if !authCheck.missingCore.isEmpty {
-            print("❤️ HealthKit 권한이 없어서 빈 데이터 반환")
-            return ExerciseData(
-                averageSteps: 0, stepsChange: 0, averageCalories: 0, caloriesChange: 0,
-                weeklySteps: Array(repeating: 0, count: 7), monthlySteps: Array(repeating: 0, count: 8),
-                dailyStepsChange: 0, weeklyStepsChange: 0, monthlyStepsChange: 0,
-                dailyCaloriesChange: 0, weeklyCaloriesChange: 0, monthlyCaloriesChange: 0
-            )
+            print("HealthKit 권한이 없어서 빈 데이터 반환")
+            throw HealthKitError.notAvailable
         }
 
         let todaySteps: Int
@@ -85,10 +98,10 @@ private extension AIInsightViewModel {
 
         do {
             todaySteps = try await healthManager.fetchStepCount()
-            print("❤️ 오늘 걸음수: \(todaySteps)")
+            print("오늘 걸음수: \(todaySteps)")
         } catch {
             print("❤️ 걸음수 가져오기 실패: \(error)")
-            todaySteps = 0
+            throw HealthKitError.notAvailable
         }
 
         do {
@@ -96,7 +109,7 @@ private extension AIInsightViewModel {
             print("❤️ 오늘 칼로리: \(todayCalories)")
         } catch {
             print("❤️ 칼로리 가져오기 실패: \(error)")
-            todayCalories = 0
+            throw HealthKitError.notAvailable
         }
 
         let yearlyData: [HealthManager.DailyMetric]
@@ -112,9 +125,9 @@ private extension AIInsightViewModel {
         let stepsChange = calculateStepsChange(from: yearlyData, current: todaySteps)
         let caloriesChange = calculateCaloriesChange(from: yearlyData, current: todayCalories)
 
-        print("❤️ 계산된 변화율:")
-        print("❤️ - 걸음수 변화: \(stepsChange)%")
-        print("❤️ - 칼로리 변화: \(caloriesChange)%")
+        print("계산된 변화율:")
+        print("- 걸음수 변화: \(stepsChange)%")
+        print("- 칼로리 변화: \(caloriesChange)%")
 
         return ExerciseData(
             averageSteps: todaySteps,

--- a/Wellnest/Wellnest/Feature/Analytics/View/SubView/ExerciseStatChartCardView.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/View/SubView/ExerciseStatChartCardView.swift
@@ -118,10 +118,11 @@ struct ExerciseStatChartCardView: View {
         }
     }
 
+    #warning("이거 지금 실데이터로 매핑하기 어려움")
     private func generateTodayData() -> [Double] {
         // 오늘의 시간대별 걸음수 (현실적인 패턴)
         let totalSteps = Double(exerciseData.averageSteps)
-        let hourlyDistribution = [0.02, 0.08, 0.12, 0.18, 0.20, 0.25, 0.15] // 더 현실적인 분포
+        let hourlyDistribution = [0.03, 0.10, 0.07, 0.05, 0.25, 0.50, 0.15] // 더 현실적인 분포
         return hourlyDistribution.map { $0 * totalSteps }
     }
 
@@ -157,8 +158,16 @@ struct ExerciseStatChartCardView: View {
         }
     }
 
+    #warning("이것 임의로 동작하도록 설정 해 둠")
     private func formatCaloriesDisplay() -> String {
-        "\(exerciseData.averageCalories)"
+        switch selectedPeriod {
+        case .today:
+            return "\(exerciseData.averageCalories)"
+        case .week:
+            return "\(Int(Double(exerciseData.averageCalories) * (1.0 + 0.1)))"
+        case .month:
+            return "\(Int(Double(exerciseData.averageCalories) * (1.0 - 0.1)))"
+        }
     }
 
     private func getStepsLabel() -> String {

--- a/Wellnest/Wellnest/Feature/Analytics/ViewModel/AnalyticsViewModel.swift
+++ b/Wellnest/Wellnest/Feature/Analytics/ViewModel/AnalyticsViewModel.swift
@@ -18,7 +18,7 @@ class AnalyticsViewModel: ObservableObject {
 
     private let healthManager = HealthManager.shared
     
-    private static let defaultExerciseData = ExerciseData(
+    static let defaultExerciseData = ExerciseData(
         averageSteps: 8500,            // 하루 평균 8,500보
         stepsChange: 300,             // 전일 대비 +300보
         averageCalories: 2100,        // 하루 평균 2,100kcal

--- a/Wellnest/Wellnest/Feature/Settings/Manager/HealthManager.swift
+++ b/Wellnest/Wellnest/Feature/Settings/Manager/HealthManager.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 import HealthKit
 
+enum HealthKitError: Error {
+    case notAvailable
+    case unknown(Error)
+}
+
 enum HealthAuthError: Error {
     case notAvailable
     case unknown(Error)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

- AI 인사이트 섹션 기본 틀 작성
- 운동/수면 섹션 데이터 없거나 못 가져올시 기본 데이터 노출 표시

## ✅ 변경사항
제가 작업한 내용입니다.
제가 할 수 있는 부분은 여기까지인 것 같습니다.

[분석탭]

1. 일정 섹션
    - 탭 뷰에 뷰모델 있고, 홈뷰와 분석뷰 공통으로 이 뷰모델을 사용

2. AI 인사이트 섹션
    - 헬스킷 데이터를 못 받아와서 테스트 진행 못함
       - 데이터가 없는 경우 task가 진행 되도록 처리해야 함. 이 처리가 안돼서 이후 프로세스가 진행되지 않음
    - 기본 AI Flow는 작성해 두었음 (데이터 가져오기 -> AI 프롬프트 생성 -> 앨런에게 AI 인사이트 요청)
       - 적절한 스크립트를 작성하고 결과는 테스트 해야 함.
    -> 더미로 보여주거나 빼는 것 추천

3. 운동/수면 섹션
    - 데이터 없거나 에러발생시 기본 데이터(더미) 보여주도록 처리
    - 수정 필요한 사항 
      - barHeight가 이상함(숫자와 그래프가 미일치) : (예) 수면시간을 8시간 넣으면 바표시는 10시간으로 돼 있음. 



## 🧪 테스트시 유의 사항
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 📝 참고

## 💜 결과
스크린샷이 있다면 첨부해주세요.
<img width="1066" height="2158" alt="CleanShot 2025-08-29 at 14 43 37" src="https://github.com/user-attachments/assets/ee263911-b4a6-4d35-a61f-ee282197e124" />

